### PR TITLE
Force locale in tests - tox uses ASCII by default which causes Click …

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ envlist = py27,pep8
 commands = nosetests
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
+         LC_ALL=C.UTF-8
+         LANG=C.UTF-8
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 


### PR DESCRIPTION
…to toss errors http://click.pocoo.org/5/python3/